### PR TITLE
use get-default-sink to get default sink

### DIFF
--- a/helpers/scripts/pulse_info.pipewire.sh
+++ b/helpers/scripts/pulse_info.pipewire.sh
@@ -3,7 +3,7 @@
 # This is a helper script for volume block
 # It prints info about current volume, mute and whether headhone is plugged or
 # not in a manner parsable by volume block
-sink="$(pactl info | awk '$1 == "Default" && $2 == "Sink:" {print $3}')"
+sink="$(pactl get-default-sink)"
 [ -n "$sink" ] || exit
 pactl list sinks | awk -v sink="$sink" '
     f {

--- a/helpers/scripts/pulse_normalize.pipewire.sh
+++ b/helpers/scripts/pulse_normalize.pipewire.sh
@@ -3,7 +3,7 @@
 # This script sets volume of both sides of output to the greatest factor of
 # "step" less than the smaller of the two
 # It is executed by volume block on middle click
-sink="$(pactl info | awk '$1 == "Default" && $2 == "Sink:" {print $3}')"
+sink="$(pactl get-default-sink)"
 [ -n "$sink" ] || exit
 volume=$(
     pactl list sinks | awk -v sink="$sink" '


### PR DESCRIPTION
idk if some old version of `pactl(1)` didn't support this, or maybe it was just an oversight, but this seems like the way to go about this